### PR TITLE
Fixing Incorrect Twitter URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ poster="https://immersive-translate.owenyoung.com/assets/twitterdeskmobile.png">
 你可以通过以下方式和我们保持联系：
 
 - [通过邮件订阅沉浸式翻译](https://immersivetranslate.substack.com/) 及时获得最新更新和 (福利)。
-- [关注沉浸式翻译的官方 Twitter](twitter.com/immersivetran)
+- [关注沉浸式翻译的官方 Twitter](https://twitter.com/immersivetran)
 - [关注 Telegram 频道](https://t.me/immersivetranslate) 接收最新消息
 - [加入 Telegram 群组](https://t.me/+rq848Z09nehlOTgx) 参与功能的讨论。
 - [问题反馈](https://github.com/immersive-translate/immersive-translate/issues/)

--- a/README_english.md
+++ b/README_english.md
@@ -28,7 +28,7 @@ This extension is free to use. I hope everyone can easily, happily and gracefull
 ## Keep in touch
 
 - [Subscribe to Immersive translation via email](https://immersivetranslate.substack.com/) Get the latest updates and (benefits) in a timely manner.
-- [Follow our Twitter](twitter.com/immersivetran)
+- [Follow our Twitter](https://twitter.com/immersivetran)
 - [Join Telegram group](https://t.me/+rq848Z09nehlOTgx) Participate in the discussion of functions.
 - [Join Telegram channel](https://t.me/immersivetranslate) Receive the latest news
 - [Question feedback](https://github.com/immersive-translate/immersive-translate/issues/)


### PR DESCRIPTION
twitter.com/immersivetran  ==> https://twitter.com/immersivetran


I noticed that the current Twitter link in the README doesn't direct to the correct address, but instead results in a relative path within the GitHub repository. This can be seen when the link is clicked, as shown in the attached screenshot.
<img width="754" alt="image" src="https://github.com/immersive-translate/immersive-translate/assets/12776182/2ca0ccd2-0e3e-47fb-9a45-2c169bb3ec1a">
<img width="1419" alt="image" src="https://github.com/immersive-translate/immersive-translate/assets/12776182/7442b71f-6cf4-40e0-b528-12f778704e9e">


The reason for this issue appears to be that the URL provided in the README doesn't include a http:// or https:// prefix. Without this prefix, GitHub may interpret the URL as a relative URL, which is an address relative to the current page. For instance, if `twitter.com/immersivetran` is written in the README, GitHub may interpret it as `https://github.com/immersive-translate/immersive-translate/blob/main/twitter.com/immersivetran`, which isn't the intended link.

To prevent this from happening, URLs should always include a `http://` or `https://` prefix. This ensures that GitHub correctly interprets the URL and transforms it into a clickable link, rather than a relative URL.

I hope this information is helpful. Please let me know if there are any questions or if further clarification is needed.

Best regards